### PR TITLE
fix: report actionable error when url input is empty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4474,46 +4474,6 @@ module.exports = CacheableRequest;
 
 /***/ }),
 
-/***/ 5204:
-/***/ ((module) => {
-
-"use strict";
-
-
-// We define these manually to ensure they're always copied
-// even if they would move up the prototype chain
-// https://nodejs.org/api/http.html#http_class_http_incomingmessage
-const knownProps = [
-	'destroy',
-	'setTimeout',
-	'socket',
-	'headers',
-	'trailers',
-	'rawHeaders',
-	'statusCode',
-	'httpVersion',
-	'httpVersionMinor',
-	'httpVersionMajor',
-	'rawTrailers',
-	'statusMessage'
-];
-
-module.exports = (fromStream, toStream) => {
-	const fromProps = new Set(Object.keys(fromStream).concat(knownProps));
-
-	for (const prop of fromProps) {
-		// Don't overwrite existing properties
-		if (prop in toStream) {
-			continue;
-		}
-
-		toStream[prop] = typeof fromStream[prop] === 'function' ? fromStream[prop].bind(fromStream) : fromStream[prop];
-	}
-};
-
-
-/***/ }),
-
 /***/ 6358:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -4521,7 +4481,7 @@ module.exports = (fromStream, toStream) => {
 
 
 const PassThrough = (__nccwpck_require__(2203).PassThrough);
-const mimicResponse = __nccwpck_require__(5204);
+const mimicResponse = __nccwpck_require__(9991);
 
 const cloneResponse = response => {
 	if (!(response && response.pipe)) {
@@ -4546,7 +4506,7 @@ module.exports = cloneResponse;
 
 const {Transform, PassThrough} = __nccwpck_require__(2203);
 const zlib = __nccwpck_require__(3106);
-const mimicResponse = __nccwpck_require__(9991);
+const mimicResponse = __nccwpck_require__(9382);
 
 module.exports = response => {
 	const contentEncoding = (response.headers['content-encoding'] || '').toLowerCase();
@@ -4600,6 +4560,91 @@ module.exports = response => {
 	response.pipe(checker).pipe(decompressStream).pipe(finalStream);
 
 	return finalStream;
+};
+
+
+/***/ }),
+
+/***/ 9382:
+/***/ ((module) => {
+
+"use strict";
+
+
+// We define these manually to ensure they're always copied
+// even if they would move up the prototype chain
+// https://nodejs.org/api/http.html#http_class_http_incomingmessage
+const knownProperties = [
+	'aborted',
+	'complete',
+	'headers',
+	'httpVersion',
+	'httpVersionMinor',
+	'httpVersionMajor',
+	'method',
+	'rawHeaders',
+	'rawTrailers',
+	'setTimeout',
+	'socket',
+	'statusCode',
+	'statusMessage',
+	'trailers',
+	'url'
+];
+
+module.exports = (fromStream, toStream) => {
+	if (toStream._readableState.autoDestroy) {
+		throw new Error('The second stream must have the `autoDestroy` option set to `false`');
+	}
+
+	const fromProperties = new Set(Object.keys(fromStream).concat(knownProperties));
+
+	const properties = {};
+
+	for (const property of fromProperties) {
+		// Don't overwrite existing properties.
+		if (property in toStream) {
+			continue;
+		}
+
+		properties[property] = {
+			get() {
+				const value = fromStream[property];
+				const isFunction = typeof value === 'function';
+
+				return isFunction ? value.bind(fromStream) : value;
+			},
+			set(value) {
+				fromStream[property] = value;
+			},
+			enumerable: true,
+			configurable: false
+		};
+	}
+
+	Object.defineProperties(toStream, properties);
+
+	fromStream.once('aborted', () => {
+		toStream.destroy();
+
+		toStream.emit('aborted');
+	});
+
+	fromStream.once('close', () => {
+		if (fromStream.complete) {
+			if (toStream.readable) {
+				toStream.once('end', () => {
+					toStream.emit('close');
+				});
+			} else {
+				toStream.emit('close');
+			}
+		} else {
+			toStream.emit('close');
+		}
+	});
+
+	return toStream;
 };
 
 
@@ -14658,77 +14703,32 @@ module.exports = object => {
 // We define these manually to ensure they're always copied
 // even if they would move up the prototype chain
 // https://nodejs.org/api/http.html#http_class_http_incomingmessage
-const knownProperties = [
-	'aborted',
-	'complete',
+const knownProps = [
+	'destroy',
+	'setTimeout',
+	'socket',
 	'headers',
+	'trailers',
+	'rawHeaders',
+	'statusCode',
 	'httpVersion',
 	'httpVersionMinor',
 	'httpVersionMajor',
-	'method',
-	'rawHeaders',
 	'rawTrailers',
-	'setTimeout',
-	'socket',
-	'statusCode',
-	'statusMessage',
-	'trailers',
-	'url'
+	'statusMessage'
 ];
 
 module.exports = (fromStream, toStream) => {
-	if (toStream._readableState.autoDestroy) {
-		throw new Error('The second stream must have the `autoDestroy` option set to `false`');
-	}
+	const fromProps = new Set(Object.keys(fromStream).concat(knownProps));
 
-	const fromProperties = new Set(Object.keys(fromStream).concat(knownProperties));
-
-	const properties = {};
-
-	for (const property of fromProperties) {
-		// Don't overwrite existing properties.
-		if (property in toStream) {
+	for (const prop of fromProps) {
+		// Don't overwrite existing properties
+		if (prop in toStream) {
 			continue;
 		}
 
-		properties[property] = {
-			get() {
-				const value = fromStream[property];
-				const isFunction = typeof value === 'function';
-
-				return isFunction ? value.bind(fromStream) : value;
-			},
-			set(value) {
-				fromStream[property] = value;
-			},
-			enumerable: true,
-			configurable: false
-		};
+		toStream[prop] = typeof fromStream[prop] === 'function' ? fromStream[prop].bind(fromStream) : fromStream[prop];
 	}
-
-	Object.defineProperties(toStream, properties);
-
-	fromStream.once('aborted', () => {
-		toStream.destroy();
-
-		toStream.emit('aborted');
-	});
-
-	fromStream.once('close', () => {
-		if (fromStream.complete) {
-			if (toStream.readable) {
-				toStream.once('end', () => {
-					toStream.emit('close');
-				});
-			} else {
-				toStream.emit('close');
-			}
-		} else {
-			toStream.emit('close');
-		}
-	});
-
-	return toStream;
 };
 
 
@@ -38004,6 +38004,10 @@ function postMessage() {
 function post(body) {
     return __awaiter(this, void 0, void 0, function* () {
         const url = core.getInput('url');
+        if (!url) {
+            throw new Error('The "url" input is empty. Check that the secret is configured and passed correctly.\n' +
+                'Note: repository secrets are unavailable to workflows triggered by fork pull requests.');
+        }
         const rsp = yield got_1.default.post(url, {
             headers: {
                 'Content-Type': 'application/json'

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,12 @@ async function postMessage(): Promise<string> {
 
 async function post(body: Message): Promise<string> {
   const url: string = core.getInput('url')
+  if (!url) {
+    throw new Error(
+      'The "url" input is empty. Check that the secret is configured and passed correctly.\n' +
+        'Note: repository secrets are unavailable to workflows triggered by fork pull requests.'
+    )
+  }
   const rsp = await got.post(url, {
     headers: {
       'Content-Type': 'application/json'


### PR DESCRIPTION
Fixes #15

## 改动

`src/main.ts` 的 `post()` 在发起请求前校验 `url` 输入。为空时输出可操作的错误并失败退出：

```text
::error::The "url" input is empty. Check that the secret is configured and passed correctly.
Note: repository secrets are unavailable to workflows triggered by fork pull requests.
```

替代原来 undici 抛出的底层错误 `No URL protocol specified`。

## 设计说明

保持"配置错误即失败"的语义不变，不静默跳过：

- action 无法区分"fork PR 无 secret（预期）"、"secret 名拼错"、"secret 未配置"。静默跳过会掩盖后两种配置错误
- 现有 @v3 消费者依赖非法 URL 即失败的契约，静默跳过属于 breaking change
- 调用方如需在 secret 缺失时跳过，应在 workflow 的 `if` 条件里处理（参考 Open-Source-Bazaar.github.io#114）

## 验证

- `tsc`、`ncc pack`、jest（1/1）、eslint、prettier 通过
- 实测空 `INPUT_URL`：输出上述错误日志，exit 1
- 正常 URL 路径不变（守卫仅空值触发）
- `dist/index.js` 已随源码重新打包


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent message submissions when the URL is missing.
  * Displays a clearer error explaining that the required secret may be unavailable, including for workflows triggered by forked pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->